### PR TITLE
fix: add from __future__ import annotations to generated pysdk types (TRADE-1143)

### DIFF
--- a/artifacts/pysdk/grvt_raw_async.py
+++ b/artifacts/pysdk/grvt_raw_async.py
@@ -13,417 +13,313 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         self.md_rpc = self.env.market_data.rpc_endpoint
         self.td_rpc = self.env.trade_data.rpc_endpoint
 
-    async def get_instrument_v1(
-        self, req: types.ApiGetInstrumentRequest
-    ) -> types.ApiGetInstrumentResponse | GrvtError:
+    async def get_instrument_v1(self, req: types.ApiGetInstrumentRequest) -> types.ApiGetInstrumentResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/instrument", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetInstrumentResponse, resp, Config(cast=[Enum]))
 
-    async def get_all_instruments_v1(
-        self, req: types.ApiGetAllInstrumentsRequest
-    ) -> types.ApiGetAllInstrumentsResponse | GrvtError:
+    async def get_all_instruments_v1(self, req: types.ApiGetAllInstrumentsRequest) -> types.ApiGetAllInstrumentsResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/all_instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAllInstrumentsResponse, resp, Config(cast=[Enum]))
 
-    async def get_filtered_instruments_v1(
-        self, req: types.ApiGetFilteredInstrumentsRequest
-    ) -> types.ApiGetFilteredInstrumentsResponse | GrvtError:
+    async def get_filtered_instruments_v1(self, req: types.ApiGetFilteredInstrumentsRequest) -> types.ApiGetFilteredInstrumentsResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum]))
 
-    async def get_currency_v1(
-        self, req: types.ApiGetCurrencyRequest
-    ) -> types.ApiGetCurrencyResponse | GrvtError:
+    async def get_currency_v1(self, req: types.ApiGetCurrencyRequest) -> types.ApiGetCurrencyResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/currency", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetCurrencyResponse, resp, Config(cast=[Enum]))
 
-    async def get_supported_assets_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetSupportedAssetsResponse | GrvtError:
+    async def get_supported_assets_v1(self, req: types.EmptyRequest) -> types.ApiGetSupportedAssetsResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/supported_assets", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetSupportedAssetsResponse, resp, Config(cast=[Enum]))
 
-    async def get_margin_rules_v1(
-        self, req: types.ApiGetMarginRulesRequest
-    ) -> types.ApiGetMarginRulesResponse | GrvtError:
+    async def get_margin_rules_v1(self, req: types.ApiGetMarginRulesRequest) -> types.ApiGetMarginRulesResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/margin_rules", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetMarginRulesResponse, resp, Config(cast=[Enum]))
 
-    async def mini_ticker_v1(
-        self, req: types.ApiMiniTickerRequest
-    ) -> types.ApiMiniTickerResponse | GrvtError:
+    async def mini_ticker_v1(self, req: types.ApiMiniTickerRequest) -> types.ApiMiniTickerResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/mini", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiMiniTickerResponse, resp, Config(cast=[Enum]))
 
-    async def ticker_v1(
-        self, req: types.ApiTickerRequest
-    ) -> types.ApiTickerResponse | GrvtError:
+    async def ticker_v1(self, req: types.ApiTickerRequest) -> types.ApiTickerResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/ticker", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTickerResponse, resp, Config(cast=[Enum]))
 
-    async def orderbook_levels_v1(
-        self, req: types.ApiOrderbookLevelsRequest
-    ) -> types.ApiOrderbookLevelsResponse | GrvtError:
+    async def orderbook_levels_v1(self, req: types.ApiOrderbookLevelsRequest) -> types.ApiOrderbookLevelsResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/book", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOrderbookLevelsResponse, resp, Config(cast=[Enum]))
 
-    async def trade_v1(
-        self, req: types.ApiTradeRequest
-    ) -> types.ApiTradeResponse | GrvtError:
+    async def trade_v1(self, req: types.ApiTradeRequest) -> types.ApiTradeResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/trade", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTradeResponse, resp, Config(cast=[Enum]))
 
-    async def trade_history_v1(
-        self, req: types.ApiTradeHistoryRequest
-    ) -> types.ApiTradeHistoryResponse | GrvtError:
+    async def trade_history_v1(self, req: types.ApiTradeHistoryRequest) -> types.ApiTradeHistoryResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/trade_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTradeHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def candlestick_v1(
-        self, req: types.ApiCandlestickRequest
-    ) -> types.ApiCandlestickResponse | GrvtError:
+    async def candlestick_v1(self, req: types.ApiCandlestickRequest) -> types.ApiCandlestickResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/kline", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiCandlestickResponse, resp, Config(cast=[Enum]))
 
-    async def funding_rate_v1(
-        self, req: types.ApiFundingRateRequest
-    ) -> types.ApiFundingRateResponse | GrvtError:
+    async def funding_rate_v1(self, req: types.ApiFundingRateRequest) -> types.ApiFundingRateResponse | GrvtError:
         resp = await self._post(False, self.md_rpc + "/full/v1/funding", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingRateResponse, resp, Config(cast=[Enum]))
 
-    async def create_order_v1(
-        self, req: types.ApiCreateOrderRequest
-    ) -> types.ApiCreateOrderResponse | GrvtError:
+    async def create_order_v1(self, req: types.ApiCreateOrderRequest) -> types.ApiCreateOrderResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/create_order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiCreateOrderResponse, resp, Config(cast=[Enum]))
 
-    async def cancel_order_v1(
-        self, req: types.ApiCancelOrderRequest
-    ) -> types.AckResponse | GrvtError:
+    async def cancel_order_v1(self, req: types.ApiCancelOrderRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/cancel_order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def cancel_all_orders_v1(
-        self, req: types.ApiCancelAllOrdersRequest
-    ) -> types.AckResponse | GrvtError:
+    async def cancel_all_orders_v1(self, req: types.ApiCancelAllOrdersRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/cancel_all_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def get_order_v1(
-        self, req: types.ApiGetOrderRequest
-    ) -> types.ApiGetOrderResponse | GrvtError:
+    async def get_order_v1(self, req: types.ApiGetOrderRequest) -> types.ApiGetOrderResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetOrderResponse, resp, Config(cast=[Enum]))
 
-    async def open_orders_v1(
-        self, req: types.ApiOpenOrdersRequest
-    ) -> types.ApiOpenOrdersResponse | GrvtError:
+    async def open_orders_v1(self, req: types.ApiOpenOrdersRequest) -> types.ApiOpenOrdersResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/open_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOpenOrdersResponse, resp, Config(cast=[Enum]))
 
-    async def order_history_v1(
-        self, req: types.ApiOrderHistoryRequest
-    ) -> types.ApiOrderHistoryResponse | GrvtError:
+    async def order_history_v1(self, req: types.ApiOrderHistoryRequest) -> types.ApiOrderHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/order_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOrderHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def cancel_on_disconnect_v1(
-        self, req: types.ApiCancelOnDisconnectRequest
-    ) -> types.AckResponse | GrvtError:
+    async def cancel_on_disconnect_v1(self, req: types.ApiCancelOnDisconnectRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/cancel_on_disconnect", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def bulk_orders_v2(
-        self, req: types.ApiBulkOrdersRequest
-    ) -> types.ApiBulkOrdersResponse | GrvtError:
+    async def bulk_orders_v2(self, req: types.ApiBulkOrdersRequest) -> types.ApiBulkOrdersResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v2/bulk_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiBulkOrdersResponse, resp, Config(cast=[Enum]))
 
-    async def fill_history_v1(
-        self, req: types.ApiFillHistoryRequest
-    ) -> types.ApiFillHistoryResponse | GrvtError:
+    async def fill_history_v1(self, req: types.ApiFillHistoryRequest) -> types.ApiFillHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/fill_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFillHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def funding_payment_history_v1(
-        self, req: types.ApiFundingPaymentHistoryRequest
-    ) -> types.ApiFundingPaymentHistoryResponse | GrvtError:
+    async def funding_payment_history_v1(self, req: types.ApiFundingPaymentHistoryRequest) -> types.ApiFundingPaymentHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/funding_payment_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def positions_v1(
-        self, req: types.ApiPositionsRequest
-    ) -> types.ApiPositionsResponse | GrvtError:
+    async def positions_v1(self, req: types.ApiPositionsRequest) -> types.ApiPositionsResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/positions", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiPositionsResponse, resp, Config(cast=[Enum]))
 
-    async def position_history_v1(
-        self, req: types.ApiPositionHistoryRequest
-    ) -> types.ApiPositionHistoryResponse | GrvtError:
+    async def position_history_v1(self, req: types.ApiPositionHistoryRequest) -> types.ApiPositionHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/position_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiPositionHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def set_position_config_v1(
-        self, req: types.ApiSetSubAccountPositionMarginConfigRequest
-    ) -> types.ApiSetSubAccountPositionMarginConfigResponse | GrvtError:
+    async def set_position_config_v1(self, req: types.ApiSetSubAccountPositionMarginConfigRequest) -> types.ApiSetSubAccountPositionMarginConfigResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/set_position_config", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum]))
 
-    async def set_sub_account_mode_v1(
-        self, req: types.ApiSetSubAccountModeRequest
-    ) -> types.ApiSetSubAccountModeResponse | GrvtError:
+    async def set_sub_account_mode_v1(self, req: types.ApiSetSubAccountModeRequest) -> types.ApiSetSubAccountModeResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/set_sub_account_mode", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetSubAccountModeResponse, resp, Config(cast=[Enum]))
 
-    async def add_position_margin_v1(
-        self, req: types.ApiAddIsolatedPositionMarginRequest
-    ) -> types.ApiAddIsolatedPositionMarginResponse | GrvtError:
+    async def add_position_margin_v1(self, req: types.ApiAddIsolatedPositionMarginRequest) -> types.ApiAddIsolatedPositionMarginResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/add_position_margin", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum]))
 
-    async def get_position_margin_limits_v1(
-        self, req: types.ApiGetIsolatedPositionMarginLimitsRequest
-    ) -> types.ApiGetIsolatedPositionMarginLimitsResponse | GrvtError:
+    async def get_position_margin_limits_v1(self, req: types.ApiGetIsolatedPositionMarginLimitsRequest) -> types.ApiGetIsolatedPositionMarginLimitsResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/get_position_margin_limits", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum]))
 
-    async def deposit_history_v1(
-        self, req: types.ApiDepositHistoryRequest
-    ) -> types.ApiDepositHistoryResponse | GrvtError:
+    async def deposit_history_v1(self, req: types.ApiDepositHistoryRequest) -> types.ApiDepositHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/deposit_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiDepositHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def transfer_v1(
-        self, req: types.ApiTransferRequest
-    ) -> types.ApiTransferResponse | GrvtError:
+    async def transfer_v1(self, req: types.ApiTransferRequest) -> types.ApiTransferResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/transfer", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTransferResponse, resp, Config(cast=[Enum]))
 
-    async def transfer_history_v1(
-        self, req: types.ApiTransferHistoryRequest
-    ) -> types.ApiTransferHistoryResponse | GrvtError:
+    async def transfer_history_v1(self, req: types.ApiTransferHistoryRequest) -> types.ApiTransferHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/transfer_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTransferHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def withdrawal_v1(
-        self, req: types.ApiWithdrawalRequest
-    ) -> types.AckResponse | GrvtError:
+    async def withdrawal_v1(self, req: types.ApiWithdrawalRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/withdrawal", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def withdrawal_history_v1(
-        self, req: types.ApiWithdrawalHistoryRequest
-    ) -> types.ApiWithdrawalHistoryResponse | GrvtError:
+    async def withdrawal_history_v1(self, req: types.ApiWithdrawalHistoryRequest) -> types.ApiWithdrawalHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/withdrawal_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiWithdrawalHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def sub_account_summary_v1(
-        self, req: types.ApiSubAccountSummaryRequest
-    ) -> types.ApiSubAccountSummaryResponse | GrvtError:
+    async def sub_account_summary_v1(self, req: types.ApiSubAccountSummaryRequest) -> types.ApiSubAccountSummaryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    async def spot_account_summary_v1(
-        self, req: types.ApiSpotSubAccountSummaryRequest
-    ) -> types.ApiSpotSubAccountSummaryResponse | GrvtError:
+    async def spot_account_summary_v1(self, req: types.ApiSpotSubAccountSummaryRequest) -> types.ApiSpotSubAccountSummaryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/spot_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    async def sub_account_history_v1(
-        self, req: types.ApiSubAccountHistoryRequest
-    ) -> types.ApiSubAccountHistoryResponse | GrvtError:
+    async def sub_account_history_v1(self, req: types.ApiSubAccountHistoryRequest) -> types.ApiSubAccountHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/account_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSubAccountHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def aggregated_account_summary_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiAggregatedAccountSummaryResponse | GrvtError:
+    async def aggregated_account_summary_v1(self, req: types.EmptyRequest) -> types.ApiAggregatedAccountSummaryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/aggregated_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    async def funding_account_summary_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiFundingAccountSummaryResponse | GrvtError:
+    async def funding_account_summary_v1(self, req: types.EmptyRequest) -> types.ApiFundingAccountSummaryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/funding_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    async def set_derisk_mm_ratio_v1(
-        self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest
-    ) -> types.ApiSetDeriskToMaintenanceMarginRatioResponse | GrvtError:
+    async def set_derisk_mm_ratio_v1(self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest) -> types.ApiSetDeriskToMaintenanceMarginRatioResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/set_derisk_mm_ratio", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum]))
 
-    async def get_sub_accounts_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetSubAccountsResponse | GrvtError:
+    async def get_sub_accounts_v1(self, req: types.EmptyRequest) -> types.ApiGetSubAccountsResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/get_sub_accounts", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetSubAccountsResponse, resp, Config(cast=[Enum]))
 
-    async def get_all_initial_leverage_v1(
-        self, req: types.ApiGetAllInitialLeverageRequest
-    ) -> types.ApiGetAllInitialLeverageResponse | GrvtError:
+    async def get_all_initial_leverage_v1(self, req: types.ApiGetAllInitialLeverageRequest) -> types.ApiGetAllInitialLeverageResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/get_all_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum]))
 
-    async def set_initial_leverage_v1(
-        self, req: types.ApiSetInitialLeverageRequest
-    ) -> types.ApiSetInitialLeverageResponse | GrvtError:
+    async def set_initial_leverage_v1(self, req: types.ApiSetInitialLeverageRequest) -> types.ApiSetInitialLeverageResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/set_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetInitialLeverageResponse, resp, Config(cast=[Enum]))
 
-    async def vault_burn_tokens_v1(
-        self, req: types.ApiVaultBurnTokensRequest
-    ) -> types.AckResponse | GrvtError:
+    async def vault_burn_tokens_v1(self, req: types.ApiVaultBurnTokensRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_burn_tokens", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def vault_invest_v1(
-        self, req: types.ApiVaultInvestRequest
-    ) -> types.AckResponse | GrvtError:
+    async def vault_invest_v1(self, req: types.ApiVaultInvestRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_invest", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def vault_investor_summary_v1(
-        self, req: types.ApiVaultInvestorSummaryRequest
-    ) -> types.ApiVaultInvestorSummaryResponse | GrvtError:
+    async def vault_investor_summary_v1(self, req: types.ApiVaultInvestorSummaryRequest) -> types.ApiVaultInvestorSummaryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_investor_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiVaultInvestorSummaryResponse, resp, Config(cast=[Enum]))
 
-    async def vault_redeem_v1(
-        self, req: types.ApiVaultRedeemRequest
-    ) -> types.AckResponse | GrvtError:
+    async def vault_redeem_v1(self, req: types.ApiVaultRedeemRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_redeem", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def vault_redeem_cancel_v1(
-        self, req: types.ApiVaultRedeemCancelRequest
-    ) -> types.AckResponse | GrvtError:
+    async def vault_redeem_cancel_v1(self, req: types.ApiVaultRedeemCancelRequest) -> types.AckResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_redeem_cancel", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    async def vault_redemption_queue_v1(
-        self, req: types.ApiVaultViewRedemptionQueueRequest
-    ) -> types.ApiVaultViewRedemptionQueueResponse | GrvtError:
+    async def vault_redemption_queue_v1(self, req: types.ApiVaultViewRedemptionQueueRequest) -> types.ApiVaultViewRedemptionQueueResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_view_redemption_queue", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum]))
 
-    async def vault_manager_investment_history_v1(
-        self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
-    ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
+    async def vault_manager_investment_history_v1(self, req: types.ApiQueryVaultManagerInvestorHistoryRequest) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/vault_manager_investor_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum]))
 
-    async def get_authorized_builders_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetAuthorizedBuildersResponse | GrvtError:
+    async def get_authorized_builders_v1(self, req: types.EmptyRequest) -> types.ApiGetAuthorizedBuildersResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/get_authorized_builders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum]))
 
-    async def builder_fill_history_v1(
-        self, req: types.ApiBuilderFillHistoryRequest
-    ) -> types.ApiBuilderFillHistoryResponse | GrvtError:
+    async def builder_fill_history_v1(self, req: types.ApiBuilderFillHistoryRequest) -> types.ApiBuilderFillHistoryResponse | GrvtError:
         resp = await self._post(True, self.td_rpc + "/full/v1/builder_fill_history", req)
         if resp.get("code"):
             return GrvtError(**resp)

--- a/artifacts/pysdk/grvt_raw_async.py
+++ b/artifacts/pysdk/grvt_raw_async.py
@@ -7,7 +7,6 @@ from .grvt_raw_base import GrvtApiConfig, GrvtError, GrvtRawAsyncBase
 
 # mypy: disable-error-code="no-any-return"
 
-
 class GrvtRawAsync(GrvtRawAsyncBase):
     def __init__(self, config: GrvtApiConfig):
         super().__init__(config)
@@ -36,9 +35,7 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         resp = await self._post(False, self.md_rpc + "/full/v1/instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum]))
 
     async def get_currency_v1(
         self, req: types.ApiGetCurrencyRequest
@@ -195,14 +192,10 @@ class GrvtRawAsync(GrvtRawAsyncBase):
     async def funding_payment_history_v1(
         self, req: types.ApiFundingPaymentHistoryRequest
     ) -> types.ApiFundingPaymentHistoryResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/funding_payment_history", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/funding_payment_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum]))
 
     async def positions_v1(
         self, req: types.ApiPositionsRequest
@@ -226,9 +219,7 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         resp = await self._post(True, self.td_rpc + "/full/v1/set_position_config", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum]))
 
     async def set_sub_account_mode_v1(
         self, req: types.ApiSetSubAccountModeRequest
@@ -244,21 +235,15 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         resp = await self._post(True, self.td_rpc + "/full/v1/add_position_margin", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum]))
 
     async def get_position_margin_limits_v1(
         self, req: types.ApiGetIsolatedPositionMarginLimitsRequest
     ) -> types.ApiGetIsolatedPositionMarginLimitsResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/get_position_margin_limits", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/get_position_margin_limits", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum]))
 
     async def deposit_history_v1(
         self, req: types.ApiDepositHistoryRequest
@@ -314,9 +299,7 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         resp = await self._post(True, self.td_rpc + "/full/v1/spot_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     async def sub_account_history_v1(
         self, req: types.ApiSubAccountHistoryRequest
@@ -329,26 +312,18 @@ class GrvtRawAsync(GrvtRawAsyncBase):
     async def aggregated_account_summary_v1(
         self, req: types.EmptyRequest
     ) -> types.ApiAggregatedAccountSummaryResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/aggregated_account_summary", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/aggregated_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     async def funding_account_summary_v1(
         self, req: types.EmptyRequest
     ) -> types.ApiFundingAccountSummaryResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/funding_account_summary", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/funding_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     async def set_derisk_mm_ratio_v1(
         self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest
@@ -356,9 +331,7 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         resp = await self._post(True, self.td_rpc + "/full/v1/set_derisk_mm_ratio", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum]))
 
     async def get_sub_accounts_v1(
         self, req: types.EmptyRequest
@@ -371,14 +344,10 @@ class GrvtRawAsync(GrvtRawAsyncBase):
     async def get_all_initial_leverage_v1(
         self, req: types.ApiGetAllInitialLeverageRequest
     ) -> types.ApiGetAllInitialLeverageResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/get_all_initial_leverage", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/get_all_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum]))
 
     async def set_initial_leverage_v1(
         self, req: types.ApiSetInitialLeverageRequest
@@ -407,9 +376,7 @@ class GrvtRawAsync(GrvtRawAsyncBase):
     async def vault_investor_summary_v1(
         self, req: types.ApiVaultInvestorSummaryRequest
     ) -> types.ApiVaultInvestorSummaryResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/vault_investor_summary", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/vault_investor_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiVaultInvestorSummaryResponse, resp, Config(cast=[Enum]))
@@ -433,38 +400,26 @@ class GrvtRawAsync(GrvtRawAsyncBase):
     async def vault_redemption_queue_v1(
         self, req: types.ApiVaultViewRedemptionQueueRequest
     ) -> types.ApiVaultViewRedemptionQueueResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/vault_view_redemption_queue", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/vault_view_redemption_queue", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum]))
 
     async def vault_manager_investment_history_v1(
         self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
     ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/vault_manager_investor_history", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/vault_manager_investor_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum]))
 
     async def get_authorized_builders_v1(
         self, req: types.EmptyRequest
     ) -> types.ApiGetAuthorizedBuildersResponse | GrvtError:
-        resp = await self._post(
-            True, self.td_rpc + "/full/v1/get_authorized_builders", req
-        )
+        resp = await self._post(True, self.td_rpc + "/full/v1/get_authorized_builders", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum]))
 
     async def builder_fill_history_v1(
         self, req: types.ApiBuilderFillHistoryRequest

--- a/artifacts/pysdk/grvt_raw_env.py
+++ b/artifacts/pysdk/grvt_raw_env.py
@@ -5,6 +5,7 @@ from enum import Enum
 class GrvtEnv(Enum):
     DEV = "dev"
     STG = "stg"
+    STAGING = "staging"
     TESTNET = "testnet"
     PROD = "prod"
 
@@ -57,7 +58,7 @@ def get_env_config(environment: GrvtEnv) -> GrvtEnvConfig:
                 ),
                 chain_id=326,
             )
-        case GrvtEnv.DEV | GrvtEnv.STG:
+        case GrvtEnv.DEV | GrvtEnv.STG | GrvtEnv.STAGING:
             return GrvtEnvConfig(
                 edge=GrvtEndpointConfig(
                     rpc_endpoint=f"https://edge.{environment.value}.gravitymarkets.io",

--- a/artifacts/pysdk/grvt_raw_sync.py
+++ b/artifacts/pysdk/grvt_raw_sync.py
@@ -13,417 +13,313 @@ class GrvtRawSync(GrvtRawSyncBase):
         self.md_rpc = self.env.market_data.rpc_endpoint
         self.td_rpc = self.env.trade_data.rpc_endpoint
 
-    def get_instrument_v1(
-        self, req: types.ApiGetInstrumentRequest
-    ) -> types.ApiGetInstrumentResponse | GrvtError:
+    def get_instrument_v1(self, req: types.ApiGetInstrumentRequest) -> types.ApiGetInstrumentResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/instrument", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetInstrumentResponse, resp, Config(cast=[Enum]))
 
-    def get_all_instruments_v1(
-        self, req: types.ApiGetAllInstrumentsRequest
-    ) -> types.ApiGetAllInstrumentsResponse | GrvtError:
+    def get_all_instruments_v1(self, req: types.ApiGetAllInstrumentsRequest) -> types.ApiGetAllInstrumentsResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/all_instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAllInstrumentsResponse, resp, Config(cast=[Enum]))
 
-    def get_filtered_instruments_v1(
-        self, req: types.ApiGetFilteredInstrumentsRequest
-    ) -> types.ApiGetFilteredInstrumentsResponse | GrvtError:
+    def get_filtered_instruments_v1(self, req: types.ApiGetFilteredInstrumentsRequest) -> types.ApiGetFilteredInstrumentsResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum]))
 
-    def get_currency_v1(
-        self, req: types.ApiGetCurrencyRequest
-    ) -> types.ApiGetCurrencyResponse | GrvtError:
+    def get_currency_v1(self, req: types.ApiGetCurrencyRequest) -> types.ApiGetCurrencyResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/currency", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetCurrencyResponse, resp, Config(cast=[Enum]))
 
-    def get_supported_assets_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetSupportedAssetsResponse | GrvtError:
+    def get_supported_assets_v1(self, req: types.EmptyRequest) -> types.ApiGetSupportedAssetsResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/supported_assets", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetSupportedAssetsResponse, resp, Config(cast=[Enum]))
 
-    def get_margin_rules_v1(
-        self, req: types.ApiGetMarginRulesRequest
-    ) -> types.ApiGetMarginRulesResponse | GrvtError:
+    def get_margin_rules_v1(self, req: types.ApiGetMarginRulesRequest) -> types.ApiGetMarginRulesResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/margin_rules", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetMarginRulesResponse, resp, Config(cast=[Enum]))
 
-    def mini_ticker_v1(
-        self, req: types.ApiMiniTickerRequest
-    ) -> types.ApiMiniTickerResponse | GrvtError:
+    def mini_ticker_v1(self, req: types.ApiMiniTickerRequest) -> types.ApiMiniTickerResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/mini", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiMiniTickerResponse, resp, Config(cast=[Enum]))
 
-    def ticker_v1(
-        self, req: types.ApiTickerRequest
-    ) -> types.ApiTickerResponse | GrvtError:
+    def ticker_v1(self, req: types.ApiTickerRequest) -> types.ApiTickerResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/ticker", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTickerResponse, resp, Config(cast=[Enum]))
 
-    def orderbook_levels_v1(
-        self, req: types.ApiOrderbookLevelsRequest
-    ) -> types.ApiOrderbookLevelsResponse | GrvtError:
+    def orderbook_levels_v1(self, req: types.ApiOrderbookLevelsRequest) -> types.ApiOrderbookLevelsResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/book", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOrderbookLevelsResponse, resp, Config(cast=[Enum]))
 
-    def trade_v1(
-        self, req: types.ApiTradeRequest
-    ) -> types.ApiTradeResponse | GrvtError:
+    def trade_v1(self, req: types.ApiTradeRequest) -> types.ApiTradeResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/trade", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTradeResponse, resp, Config(cast=[Enum]))
 
-    def trade_history_v1(
-        self, req: types.ApiTradeHistoryRequest
-    ) -> types.ApiTradeHistoryResponse | GrvtError:
+    def trade_history_v1(self, req: types.ApiTradeHistoryRequest) -> types.ApiTradeHistoryResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/trade_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTradeHistoryResponse, resp, Config(cast=[Enum]))
 
-    def candlestick_v1(
-        self, req: types.ApiCandlestickRequest
-    ) -> types.ApiCandlestickResponse | GrvtError:
+    def candlestick_v1(self, req: types.ApiCandlestickRequest) -> types.ApiCandlestickResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/kline", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiCandlestickResponse, resp, Config(cast=[Enum]))
 
-    def funding_rate_v1(
-        self, req: types.ApiFundingRateRequest
-    ) -> types.ApiFundingRateResponse | GrvtError:
+    def funding_rate_v1(self, req: types.ApiFundingRateRequest) -> types.ApiFundingRateResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/funding", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingRateResponse, resp, Config(cast=[Enum]))
 
-    def create_order_v1(
-        self, req: types.ApiCreateOrderRequest
-    ) -> types.ApiCreateOrderResponse | GrvtError:
+    def create_order_v1(self, req: types.ApiCreateOrderRequest) -> types.ApiCreateOrderResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/create_order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiCreateOrderResponse, resp, Config(cast=[Enum]))
 
-    def cancel_order_v1(
-        self, req: types.ApiCancelOrderRequest
-    ) -> types.AckResponse | GrvtError:
+    def cancel_order_v1(self, req: types.ApiCancelOrderRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/cancel_order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def cancel_all_orders_v1(
-        self, req: types.ApiCancelAllOrdersRequest
-    ) -> types.AckResponse | GrvtError:
+    def cancel_all_orders_v1(self, req: types.ApiCancelAllOrdersRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/cancel_all_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def get_order_v1(
-        self, req: types.ApiGetOrderRequest
-    ) -> types.ApiGetOrderResponse | GrvtError:
+    def get_order_v1(self, req: types.ApiGetOrderRequest) -> types.ApiGetOrderResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/order", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetOrderResponse, resp, Config(cast=[Enum]))
 
-    def open_orders_v1(
-        self, req: types.ApiOpenOrdersRequest
-    ) -> types.ApiOpenOrdersResponse | GrvtError:
+    def open_orders_v1(self, req: types.ApiOpenOrdersRequest) -> types.ApiOpenOrdersResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/open_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOpenOrdersResponse, resp, Config(cast=[Enum]))
 
-    def order_history_v1(
-        self, req: types.ApiOrderHistoryRequest
-    ) -> types.ApiOrderHistoryResponse | GrvtError:
+    def order_history_v1(self, req: types.ApiOrderHistoryRequest) -> types.ApiOrderHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/order_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiOrderHistoryResponse, resp, Config(cast=[Enum]))
 
-    def cancel_on_disconnect_v1(
-        self, req: types.ApiCancelOnDisconnectRequest
-    ) -> types.AckResponse | GrvtError:
+    def cancel_on_disconnect_v1(self, req: types.ApiCancelOnDisconnectRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/cancel_on_disconnect", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def bulk_orders_v2(
-        self, req: types.ApiBulkOrdersRequest
-    ) -> types.ApiBulkOrdersResponse | GrvtError:
+    def bulk_orders_v2(self, req: types.ApiBulkOrdersRequest) -> types.ApiBulkOrdersResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v2/bulk_orders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiBulkOrdersResponse, resp, Config(cast=[Enum]))
 
-    def fill_history_v1(
-        self, req: types.ApiFillHistoryRequest
-    ) -> types.ApiFillHistoryResponse | GrvtError:
+    def fill_history_v1(self, req: types.ApiFillHistoryRequest) -> types.ApiFillHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/fill_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFillHistoryResponse, resp, Config(cast=[Enum]))
 
-    def funding_payment_history_v1(
-        self, req: types.ApiFundingPaymentHistoryRequest
-    ) -> types.ApiFundingPaymentHistoryResponse | GrvtError:
+    def funding_payment_history_v1(self, req: types.ApiFundingPaymentHistoryRequest) -> types.ApiFundingPaymentHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/funding_payment_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum]))
 
-    def positions_v1(
-        self, req: types.ApiPositionsRequest
-    ) -> types.ApiPositionsResponse | GrvtError:
+    def positions_v1(self, req: types.ApiPositionsRequest) -> types.ApiPositionsResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/positions", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiPositionsResponse, resp, Config(cast=[Enum]))
 
-    def position_history_v1(
-        self, req: types.ApiPositionHistoryRequest
-    ) -> types.ApiPositionHistoryResponse | GrvtError:
+    def position_history_v1(self, req: types.ApiPositionHistoryRequest) -> types.ApiPositionHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/position_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiPositionHistoryResponse, resp, Config(cast=[Enum]))
 
-    def set_position_config_v1(
-        self, req: types.ApiSetSubAccountPositionMarginConfigRequest
-    ) -> types.ApiSetSubAccountPositionMarginConfigResponse | GrvtError:
+    def set_position_config_v1(self, req: types.ApiSetSubAccountPositionMarginConfigRequest) -> types.ApiSetSubAccountPositionMarginConfigResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/set_position_config", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum]))
 
-    def set_sub_account_mode_v1(
-        self, req: types.ApiSetSubAccountModeRequest
-    ) -> types.ApiSetSubAccountModeResponse | GrvtError:
+    def set_sub_account_mode_v1(self, req: types.ApiSetSubAccountModeRequest) -> types.ApiSetSubAccountModeResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/set_sub_account_mode", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetSubAccountModeResponse, resp, Config(cast=[Enum]))
 
-    def add_position_margin_v1(
-        self, req: types.ApiAddIsolatedPositionMarginRequest
-    ) -> types.ApiAddIsolatedPositionMarginResponse | GrvtError:
+    def add_position_margin_v1(self, req: types.ApiAddIsolatedPositionMarginRequest) -> types.ApiAddIsolatedPositionMarginResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/add_position_margin", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum]))
 
-    def get_position_margin_limits_v1(
-        self, req: types.ApiGetIsolatedPositionMarginLimitsRequest
-    ) -> types.ApiGetIsolatedPositionMarginLimitsResponse | GrvtError:
+    def get_position_margin_limits_v1(self, req: types.ApiGetIsolatedPositionMarginLimitsRequest) -> types.ApiGetIsolatedPositionMarginLimitsResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/get_position_margin_limits", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum]))
 
-    def deposit_history_v1(
-        self, req: types.ApiDepositHistoryRequest
-    ) -> types.ApiDepositHistoryResponse | GrvtError:
+    def deposit_history_v1(self, req: types.ApiDepositHistoryRequest) -> types.ApiDepositHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/deposit_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiDepositHistoryResponse, resp, Config(cast=[Enum]))
 
-    def transfer_v1(
-        self, req: types.ApiTransferRequest
-    ) -> types.ApiTransferResponse | GrvtError:
+    def transfer_v1(self, req: types.ApiTransferRequest) -> types.ApiTransferResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/transfer", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTransferResponse, resp, Config(cast=[Enum]))
 
-    def transfer_history_v1(
-        self, req: types.ApiTransferHistoryRequest
-    ) -> types.ApiTransferHistoryResponse | GrvtError:
+    def transfer_history_v1(self, req: types.ApiTransferHistoryRequest) -> types.ApiTransferHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/transfer_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiTransferHistoryResponse, resp, Config(cast=[Enum]))
 
-    def withdrawal_v1(
-        self, req: types.ApiWithdrawalRequest
-    ) -> types.AckResponse | GrvtError:
+    def withdrawal_v1(self, req: types.ApiWithdrawalRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/withdrawal", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def withdrawal_history_v1(
-        self, req: types.ApiWithdrawalHistoryRequest
-    ) -> types.ApiWithdrawalHistoryResponse | GrvtError:
+    def withdrawal_history_v1(self, req: types.ApiWithdrawalHistoryRequest) -> types.ApiWithdrawalHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/withdrawal_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiWithdrawalHistoryResponse, resp, Config(cast=[Enum]))
 
-    def sub_account_summary_v1(
-        self, req: types.ApiSubAccountSummaryRequest
-    ) -> types.ApiSubAccountSummaryResponse | GrvtError:
+    def sub_account_summary_v1(self, req: types.ApiSubAccountSummaryRequest) -> types.ApiSubAccountSummaryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    def spot_account_summary_v1(
-        self, req: types.ApiSpotSubAccountSummaryRequest
-    ) -> types.ApiSpotSubAccountSummaryResponse | GrvtError:
+    def spot_account_summary_v1(self, req: types.ApiSpotSubAccountSummaryRequest) -> types.ApiSpotSubAccountSummaryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/spot_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    def sub_account_history_v1(
-        self, req: types.ApiSubAccountHistoryRequest
-    ) -> types.ApiSubAccountHistoryResponse | GrvtError:
+    def sub_account_history_v1(self, req: types.ApiSubAccountHistoryRequest) -> types.ApiSubAccountHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/account_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSubAccountHistoryResponse, resp, Config(cast=[Enum]))
 
-    def aggregated_account_summary_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiAggregatedAccountSummaryResponse | GrvtError:
+    def aggregated_account_summary_v1(self, req: types.EmptyRequest) -> types.ApiAggregatedAccountSummaryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/aggregated_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    def funding_account_summary_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiFundingAccountSummaryResponse | GrvtError:
+    def funding_account_summary_v1(self, req: types.EmptyRequest) -> types.ApiFundingAccountSummaryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/funding_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum]))
 
-    def set_derisk_mm_ratio_v1(
-        self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest
-    ) -> types.ApiSetDeriskToMaintenanceMarginRatioResponse | GrvtError:
+    def set_derisk_mm_ratio_v1(self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest) -> types.ApiSetDeriskToMaintenanceMarginRatioResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/set_derisk_mm_ratio", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum]))
 
-    def get_sub_accounts_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetSubAccountsResponse | GrvtError:
+    def get_sub_accounts_v1(self, req: types.EmptyRequest) -> types.ApiGetSubAccountsResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/get_sub_accounts", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetSubAccountsResponse, resp, Config(cast=[Enum]))
 
-    def get_all_initial_leverage_v1(
-        self, req: types.ApiGetAllInitialLeverageRequest
-    ) -> types.ApiGetAllInitialLeverageResponse | GrvtError:
+    def get_all_initial_leverage_v1(self, req: types.ApiGetAllInitialLeverageRequest) -> types.ApiGetAllInitialLeverageResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/get_all_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum]))
 
-    def set_initial_leverage_v1(
-        self, req: types.ApiSetInitialLeverageRequest
-    ) -> types.ApiSetInitialLeverageResponse | GrvtError:
+    def set_initial_leverage_v1(self, req: types.ApiSetInitialLeverageRequest) -> types.ApiSetInitialLeverageResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/set_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiSetInitialLeverageResponse, resp, Config(cast=[Enum]))
 
-    def vault_burn_tokens_v1(
-        self, req: types.ApiVaultBurnTokensRequest
-    ) -> types.AckResponse | GrvtError:
+    def vault_burn_tokens_v1(self, req: types.ApiVaultBurnTokensRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_burn_tokens", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def vault_invest_v1(
-        self, req: types.ApiVaultInvestRequest
-    ) -> types.AckResponse | GrvtError:
+    def vault_invest_v1(self, req: types.ApiVaultInvestRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_invest", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def vault_investor_summary_v1(
-        self, req: types.ApiVaultInvestorSummaryRequest
-    ) -> types.ApiVaultInvestorSummaryResponse | GrvtError:
+    def vault_investor_summary_v1(self, req: types.ApiVaultInvestorSummaryRequest) -> types.ApiVaultInvestorSummaryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_investor_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiVaultInvestorSummaryResponse, resp, Config(cast=[Enum]))
 
-    def vault_redeem_v1(
-        self, req: types.ApiVaultRedeemRequest
-    ) -> types.AckResponse | GrvtError:
+    def vault_redeem_v1(self, req: types.ApiVaultRedeemRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_redeem", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def vault_redeem_cancel_v1(
-        self, req: types.ApiVaultRedeemCancelRequest
-    ) -> types.AckResponse | GrvtError:
+    def vault_redeem_cancel_v1(self, req: types.ApiVaultRedeemCancelRequest) -> types.AckResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_redeem_cancel", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.AckResponse, resp, Config(cast=[Enum]))
 
-    def vault_redemption_queue_v1(
-        self, req: types.ApiVaultViewRedemptionQueueRequest
-    ) -> types.ApiVaultViewRedemptionQueueResponse | GrvtError:
+    def vault_redemption_queue_v1(self, req: types.ApiVaultViewRedemptionQueueRequest) -> types.ApiVaultViewRedemptionQueueResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_view_redemption_queue", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum]))
 
-    def vault_manager_investment_history_v1(
-        self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
-    ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
+    def vault_manager_investment_history_v1(self, req: types.ApiQueryVaultManagerInvestorHistoryRequest) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/vault_manager_investor_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum]))
 
-    def get_authorized_builders_v1(
-        self, req: types.EmptyRequest
-    ) -> types.ApiGetAuthorizedBuildersResponse | GrvtError:
+    def get_authorized_builders_v1(self, req: types.EmptyRequest) -> types.ApiGetAuthorizedBuildersResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/get_authorized_builders", req)
         if resp.get("code"):
             return GrvtError(**resp)
         return from_dict(types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum]))
 
-    def builder_fill_history_v1(
-        self, req: types.ApiBuilderFillHistoryRequest
-    ) -> types.ApiBuilderFillHistoryResponse | GrvtError:
+    def builder_fill_history_v1(self, req: types.ApiBuilderFillHistoryRequest) -> types.ApiBuilderFillHistoryResponse | GrvtError:
         resp = self._post(True, self.td_rpc + "/full/v1/builder_fill_history", req)
         if resp.get("code"):
             return GrvtError(**resp)

--- a/artifacts/pysdk/grvt_raw_sync.py
+++ b/artifacts/pysdk/grvt_raw_sync.py
@@ -7,7 +7,6 @@ from .grvt_raw_base import GrvtApiConfig, GrvtError, GrvtRawSyncBase
 
 # mypy: disable-error-code="no-any-return"
 
-
 class GrvtRawSync(GrvtRawSyncBase):
     def __init__(self, config: GrvtApiConfig):
         super().__init__(config)
@@ -36,9 +35,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(False, self.md_rpc + "/full/v1/instruments", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum]))
 
     def get_currency_v1(
         self, req: types.ApiGetCurrencyRequest
@@ -88,7 +85,9 @@ class GrvtRawSync(GrvtRawSyncBase):
             return GrvtError(**resp)
         return from_dict(types.ApiOrderbookLevelsResponse, resp, Config(cast=[Enum]))
 
-    def trade_v1(self, req: types.ApiTradeRequest) -> types.ApiTradeResponse | GrvtError:
+    def trade_v1(
+        self, req: types.ApiTradeRequest
+    ) -> types.ApiTradeResponse | GrvtError:
         resp = self._post(False, self.md_rpc + "/full/v1/trade", req)
         if resp.get("code"):
             return GrvtError(**resp)
@@ -196,9 +195,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/funding_payment_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiFundingPaymentHistoryResponse, resp, Config(cast=[Enum]))
 
     def positions_v1(
         self, req: types.ApiPositionsRequest
@@ -222,9 +219,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/set_position_config", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSetSubAccountPositionMarginConfigResponse, resp, Config(cast=[Enum]))
 
     def set_sub_account_mode_v1(
         self, req: types.ApiSetSubAccountModeRequest
@@ -240,9 +235,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/add_position_margin", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiAddIsolatedPositionMarginResponse, resp, Config(cast=[Enum]))
 
     def get_position_margin_limits_v1(
         self, req: types.ApiGetIsolatedPositionMarginLimitsRequest
@@ -250,9 +243,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/get_position_margin_limits", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetIsolatedPositionMarginLimitsResponse, resp, Config(cast=[Enum]))
 
     def deposit_history_v1(
         self, req: types.ApiDepositHistoryRequest
@@ -308,9 +299,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/spot_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSpotSubAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     def sub_account_history_v1(
         self, req: types.ApiSubAccountHistoryRequest
@@ -326,9 +315,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/aggregated_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiAggregatedAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     def funding_account_summary_v1(
         self, req: types.EmptyRequest
@@ -336,9 +323,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/funding_account_summary", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiFundingAccountSummaryResponse, resp, Config(cast=[Enum]))
 
     def set_derisk_mm_ratio_v1(
         self, req: types.ApiSetDeriskToMaintenanceMarginRatioRequest
@@ -346,9 +331,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/set_derisk_mm_ratio", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiSetDeriskToMaintenanceMarginRatioResponse, resp, Config(cast=[Enum]))
 
     def get_sub_accounts_v1(
         self, req: types.EmptyRequest
@@ -364,9 +347,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/get_all_initial_leverage", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetAllInitialLeverageResponse, resp, Config(cast=[Enum]))
 
     def set_initial_leverage_v1(
         self, req: types.ApiSetInitialLeverageRequest
@@ -422,21 +403,15 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/vault_view_redemption_queue", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum]))
 
     def vault_manager_investment_history_v1(
         self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
     ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
-        resp = self._post(
-            True, self.td_rpc + "/full/v1/vault_manager_investor_history", req
-        )
+        resp = self._post(True, self.td_rpc + "/full/v1/vault_manager_investor_history", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum]))
 
     def get_authorized_builders_v1(
         self, req: types.EmptyRequest
@@ -444,9 +419,7 @@ class GrvtRawSync(GrvtRawSyncBase):
         resp = self._post(True, self.td_rpc + "/full/v1/get_authorized_builders", req)
         if resp.get("code"):
             return GrvtError(**resp)
-        return from_dict(
-            types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum])
-        )
+        return from_dict(types.ApiGetAuthorizedBuildersResponse, resp, Config(cast=[Enum]))
 
     def builder_fill_history_v1(
         self, req: types.ApiBuilderFillHistoryRequest

--- a/artifacts/pysdk/grvt_raw_types.py
+++ b/artifacts/pysdk/grvt_raw_types.py
@@ -5,6 +5,8 @@
 # ruff: noqa: W291
 # ruff: noqa: D400
 # ruff: noqa: E501
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -221,9 +223,7 @@ class OrderRejectReason(Enum):
     # the subaccount has insufficient balance
     INSUFFICIENT_BALANCE = "INSUFFICIENT_BALANCE"
     # spot trading is blocked during socialized loss (SLOW)
-    SPOT_TRADING_BLOCKED_DURING_SOCIALIZED_LOSS = (
-        "SPOT_TRADING_BLOCKED_DURING_SOCIALIZED_LOSS"
-    )
+    SPOT_TRADING_BLOCKED_DURING_SOCIALIZED_LOSS = "SPOT_TRADING_BLOCKED_DURING_SOCIALIZED_LOSS"
     # the order will bring the sub account below initial margin requirement considering wide price deviation
     BELOW_MARGIN_WITH_PENALTY_DEVIATION = "BELOW_MARGIN_WITH_PENALTY_DEVIATION"
 
@@ -857,7 +857,6 @@ class ApiGetAuthorizedBuildersResponse:
 @dataclass
 class ApiGetCurrencyRequest:
     pass
-
 
 @dataclass
 class ApiGetCurrencyResponse:
@@ -1716,7 +1715,7 @@ class BuilderFillHistory:
     mark_price: str
     # The index price of the instrument at point of trade, expressed in `9` decimals
     index_price: str
-    # Builder fee percentage charged for this order. referred to Order.builder builderFee
+    # Builder fee percentage charged for this order. referred to Order.builder builderFee 
     fee_rate: str
     # The builder fee paid on the trade, expressed in quote asset decimal unit. referred to Trade.builderFee
     fee: str
@@ -1821,7 +1820,6 @@ class DepositHistory:
 class EmptyRequest:
     pass
 
-
 @dataclass
 class Error:
     # The error code for the request
@@ -1886,7 +1884,7 @@ class Fill:
     is_rpi: bool
     # The main account ID of the builder. referred to Order.builder
     builder: str
-    # Builder fee percentage charged for this order. referred to Order.builder builderFee
+    # Builder fee percentage charged for this order. referred to Order.builder builderFee 
     builder_fee_rate: str
     # The builder fee paid on the trade, expressed in quote asset decimal unit. referred to Trade.builderFee
     builder_fee: str
@@ -2101,7 +2099,7 @@ class Order:
     metadata: OrderMetadata
     # The main account ID of the builder
     builder: str
-    # Builder fee charged for this order, expressed as a percentage (e.g., 0.001 means 0.001%).
+    # Builder fee charged for this order, expressed as a percentage (e.g., 0.001 means 0.001%). 
     builder_fee: str
     # [Filled by GRVT Backend] A unique 128-bit identifier for the order, deterministically generated within the GRVT backend
     order_id: str | None = None
@@ -2836,7 +2834,6 @@ class WSFillFeedSelectorV1:
 class WSListStreamsParams:
     pass
 
-
 @dataclass
 class WSListStreamsResult:
     # The list of stream references  the connection is connected to
@@ -3246,7 +3243,6 @@ class WSTransferFeedSelectorV1:
 class WSUnsubscribeAllParams:
     pass
 
-
 @dataclass
 class WSUnsubscribeAllResult:
     # The list of stream references unsubscribed from
@@ -3337,3 +3333,5 @@ class WithdrawalHistory:
     l_2_hash: str
     # The finalized withdrawal transaction hash on L1, empty if the withdrawal is 'pending'.
     l_1_hash: str | None = None
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ testpaths = "tests"
 [tool.ruff]
 extend-exclude = [
     "__pycache__",
+    "artifacts",
     "build",
     "dist",
 ]

--- a/src/codegen/pysdk/pysdk.py
+++ b/src/codegen/pysdk/pysdk.py
@@ -148,7 +148,9 @@ def write_rpc_api(spec_root: SpecRoot, f: TextIOWrapper, is_async: bool) -> None
             rpc_var = "md" if gateway.name == "MarketData" else "td"
             func_name = inflection.underscore(rpc.name[3:]).lower()
 
-            f.write(f"    {method_prefix}def {func_name}(self, req: types.{rpc.request}) -> types.{rpc.response} | GrvtError:\n")
+            f.write(
+                f"    {method_prefix}def {func_name}(self, req: types.{rpc.request}) -> types.{rpc.response} | GrvtError:\n"
+            )
             f.write(
                 f"        resp = {await_prefix}self._post({rpc.auth_required},"
                 + f' self.{rpc_var}_rpc + "/full/v{rpc.version}{rpc.route}", req)\n'

--- a/src/codegen/pysdk/pysdk.py
+++ b/src/codegen/pysdk/pysdk.py
@@ -174,6 +174,7 @@ def generate(spec_root: SpecRoot) -> None:
         f.write("# ruff: noqa: W291\n")
         f.write("# ruff: noqa: D400\n")
         f.write("# ruff: noqa: E501\n")
+        f.write("from __future__ import annotations\n\n")
         f.write("from dataclasses import dataclass\n")
         f.write("from enum import Enum\n")
         f.write("from typing import Any\n\n\n")

--- a/src/codegen/pysdk/pysdk.py
+++ b/src/codegen/pysdk/pysdk.py
@@ -148,9 +148,7 @@ def write_rpc_api(spec_root: SpecRoot, f: TextIOWrapper, is_async: bool) -> None
             rpc_var = "md" if gateway.name == "MarketData" else "td"
             func_name = inflection.underscore(rpc.name[3:]).lower()
 
-            f.write(f"    {method_prefix}def {func_name}(\n")
-            f.write(f"        self, req: types.{rpc.request}\n")
-            f.write(f"    ) -> types.{rpc.response} | GrvtError:\n")
+            f.write(f"    {method_prefix}def {func_name}(self, req: types.{rpc.request}) -> types.{rpc.response} | GrvtError:\n")
             f.write(
                 f"        resp = {await_prefix}self._post({rpc.auth_required},"
                 + f' self.{rpc_var}_rpc + "/full/v{rpc.version}{rpc.route}", req)\n'


### PR DESCRIPTION
## Summary

- Fixes `NameError: name 'SpotBalance' is not defined` in `grvt_raw_types.py` breaking CI since PR #80 (Jan 2026)
- Root cause: Python 3.12 evaluates `list[T]` eagerly at class definition time; after PR #80 reordered `apispec.json`, `AggregatedAccountSummary` appeared before `SpotBalance` in the generated file
- Fix: emit `from __future__ import annotations` (PEP 563) in the `grvt_raw_types.py` header — makes all annotations lazy strings so struct ordering in `apispec.json` no longer matters
- Excludes `artifacts/` from ruff lint and format (generated files)
- Restores `GrvtEnv.STAGING` which was missing from the enum, fixing test default

## Test plan

- [ ] CI passes (no more `NameError` during test collection)
- [ ] `grvt_raw_types.py` imports cleanly under Python 3.12
- [ ] All 5 tests pass